### PR TITLE
Add dummy keys for placeholder table row and column

### DIFF
--- a/rjt.js
+++ b/rjt.js
@@ -63,7 +63,7 @@ var JsonTable = React.createClass({
 		;
 
 		if( !items || !items.length )
-			return $.tbody({key:'body'}, [$.tr({}, $.td({}, this.getSetting('noRowsMessage') ))]);
+			return $.tbody({key:'body'}, [$.tr({key:'row'}, $.td({key:'column'}, this.getSetting('noRowsMessage') ))]);
 
 		var rows = items.map( function( item ){
 			var key = me.getKey( item, i );


### PR DESCRIPTION
Hello,

Nothing serious, but there is a warning when the table is initialised with an empty items set and placeholder table is displayed.

`Warning: Each child in an array or iterator should have a unique "key" prop. Check the top-level render call using <tbody>. See https://fb.me/react-warning-keys for more information.`

To solve that issue, we need dummy keys for that placeholder table.

Best regards,
Harri
